### PR TITLE
Completed Lesson 5.1: Sorting Searching Pagination

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ function App() {
   const [todoList, setTodoList] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [sortOrder, setSortOrder] = useState('asc');
 
   const fetchData = async () => {
     setIsLoading(true);
@@ -21,7 +22,7 @@ function App() {
       },
     };
 
-    const url = `https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}`;
+    const url = `https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view&sort[0][field]=title&sort[0][direction]=asc`;
 
     try {
       const response = await fetch(url, options);
@@ -32,11 +33,26 @@ function App() {
       }
 
       const data = await response.json();
-      const todos = data.records.map((record) => ({
-        title: record.fields.title,
-        id: record.id,
-        completedAt: record.fields.completedAt || null,
-      }));
+      
+      const todos = data.records
+        .map((record) => ({
+          title: record.fields.title,
+          id: record.id,
+          completedAt: record.fields.completedAt || null,
+        }))
+        .sort((objectA, objectB) => {
+          const titleA = objectA.title.toLowerCase();
+          const titleB = objectB.title.toLowerCase();
+
+          if (sortOrder === 'asc') {
+            if (titleA < titleB) return -1;
+            if (titleA > titleB) return 1;
+          } else {
+            if (titleA < titleB) return 1;
+            if (titleA > titleB) return -1;
+          }
+          return 0;
+        });
 
       setTodoList(todos);
     } catch (error) {
@@ -49,7 +65,7 @@ function App() {
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [sortOrder]);
 
   useEffect(() => {
     if (!isLoading) {
@@ -163,6 +179,10 @@ function App() {
     }
   }, []);
 
+  const toggleSortOrder = () => {
+    setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+  };
+
   return (
     <Router>
       <div className="container">
@@ -175,6 +195,9 @@ function App() {
                   <FaClipboardList className="icon" />
                   <h1>Todo List</h1>
                 </div>
+                <button onClick={toggleSortOrder}>
+                  Toggle Sort Order ({sortOrder === 'asc' ? 'A-Z' : 'Z-A'})
+                </button>
                 <div className="add-todo-form">
                   <AddTodoForm onAddTodo={addTodo} />
                 </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ function App() {
       }
 
       const data = await response.json();
-      
+
       const todos = data.records
         .map((record) => ({
           title: record.fields.title,
@@ -45,13 +45,10 @@ function App() {
           const titleB = objectB.title.toLowerCase();
 
           if (sortOrder === 'asc') {
-            if (titleA < titleB) return -1;
-            if (titleA > titleB) return 1;
+            return titleA < titleB ? -1 : titleA > titleB ? 1 : 0;
           } else {
-            if (titleA < titleB) return 1;
-            if (titleA > titleB) return -1;
+            return titleA < titleB ? 1 : titleA > titleB ? -1 : 0;
           }
-          return 0;
         });
 
       setTodoList(todos);
@@ -68,9 +65,13 @@ function App() {
   }, [sortOrder]);
 
   useEffect(() => {
-    if (!isLoading) {
-      localStorage.setItem('savedTodoList', JSON.stringify(todoList));
-    }
+    const debounceSave = setTimeout(() => {
+      if (!isLoading) {
+        localStorage.setItem('savedTodoList', JSON.stringify(todoList));
+      }
+    }, 500);
+
+    return () => clearTimeout(debounceSave);
   }, [todoList, isLoading]);
 
   const addTodo = useCallback(async (newTodoTitle) => {
@@ -180,7 +181,7 @@ function App() {
   }, []);
 
   const toggleSortOrder = () => {
-    setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    setSortOrder((prevOrder) => (prevOrder === 'asc' ? 'desc' : 'asc'));
   };
 
   return (


### PR DESCRIPTION
- Added sorting by Airtable "Title" field in ascending order in the API request.
- Implemented JavaScript sorting for the todo list with an option to toggle between ascending (A-Z) and descending (Z-A) order.
- Added a button to toggle sort order in the UI.
- Updated the Airtable API call to fetch data based on the "Grid view."

Minor optimizations suggestions
- **Debouncing `localStorage` updates**: The `useEffect` that handles saving to `localStorage` is now debounced by 500ms.
- **Improved `toggleSortOrder`**: The `setSortOrder` function now uses the previous state to update the sort order.